### PR TITLE
"tupel" -> "tuple"

### DIFF
--- a/sections/projectives_in_the_category_of_quiver_representations.tex
+++ b/sections/projectives_in_the_category_of_quiver_representations.tex
@@ -535,7 +535,7 @@
 
 
 \begin{definition*}
-  The \emph{dimension vector}\index{dimension vector} of a {\fd} representation~$X$ of~$Q$ over~$\kf$ is the tupel
+  The \emph{dimension vector}\index{dimension vector} of a {\fd} representation~$X$ of~$Q$ over~$\kf$ is the tuple
   \[
     \dimvect X
     \defined

--- a/sections/representations_of_quivers.tex
+++ b/sections/representations_of_quivers.tex
@@ -16,7 +16,7 @@
   Let~$X$,~$Y$ and~$Z$ be representations of~$Q$.
   \begin{enumerate}[resume]
     \item
-      A \emph{homomorphism}\index{homomorphism!of quiver representations}~$f \colon X \to Y$ is a tupel~$(f_i)_{i \in Q_0}$ of~{\klin} maps~$f_i \colon X_i \to Y_i$ such that the square
+      A \emph{homomorphism}\index{homomorphism!of quiver representations}~$f \colon X \to Y$ is a tuple~$(f_i)_{i \in Q_0}$ of~{\klin} maps~$f_i \colon X_i \to Y_i$ such that the square
       \[
         \begin{tikzcd}
             X_{s(\alpha)}
@@ -448,7 +448,7 @@
       It follows in particular that if~$Q$ has no oriented cycles then a~{\module{$\kf Q$}}~$M$ is finitely generated as an~{\module{$\kf Q$}} if and only if it is is finitely generated as a~{\module{$\kf$}}.
       If~$\kf$ is additionally a field, then this means that~$M$ is finitely generated as a~{\module{$\kf Q$}} if and only if it is {\fd}.
     \item
-      If~$X$ is a representation of~$Q$ over~$\kf$ then a \emph{subrepresentation}\index{sub-!representation} of~$X$ is a tupel~$Y = (Y_i)_{i \in Q_0}$ of~{\submodules{$\kf$}}~$Y_i \subseteq X_i$ such that~$X_\alpha( Y_{s(\alpha)} ) \subseteq Y_{t(\alpha)}$ for every arrow~$\alpha \in Q_1$.
+      If~$X$ is a representation of~$Q$ over~$\kf$ then a \emph{subrepresentation}\index{sub-!representation} of~$X$ is a tuple~$Y = (Y_i)_{i \in Q_0}$ of~{\submodules{$\kf$}}~$Y_i \subseteq X_i$ such that~$X_\alpha( Y_{s(\alpha)} ) \subseteq Y_{t(\alpha)}$ for every arrow~$\alpha \in Q_1$.
       
       If~$(Y_i)_{i \in Q_0}$ is a subrepresentation of~$X$ and~$Y_\alpha \colon Y_{s(\alpha)} \to Y_{t(\alpha)}$ is for every arrow~$\alpha \in Q_1$ the restriction of the~{\klin} map~$X_\alpha$, then this defines a representation~$Y$ of~$Q$ of~$\kf$.
       The inclusion~$\iota = (\iota_i)_{i \in Q_0} \colon Y \to X$ that it at every vertex~$i \in Q_0$ given by the inclusion~$\iota_i \colon Y_i \to X_i$ is then a homomorphism of representations.


### PR DESCRIPTION
Found a small typo